### PR TITLE
[FEAT] API 응답 스펙 및 Pydantic 모델 정의

### DIFF
--- a/api/schemas.py
+++ b/api/schemas.py
@@ -1,12 +1,13 @@
-from typing import Optional, Literal
+from typing import Literal, Optional
+
 from pydantic import BaseModel
 
 
 class ExtractionResult(BaseModel):
     url: str
-    title: Optional[str] = None
-    brand: Optional[str] = None
-    image_url: Optional[str] = None
+    productName: Optional[str] = None
+    brandName: Optional[str] = None
+    imageUrl: Optional[str] = None
     extracted_via: Optional[Literal["static", "playwright", "error"]] = None
 
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

[DK-462](https://potenup-final.atlassian.net/browse/DK-462)

## 📝 작업 내용
- 사전에 논의한 응답 스펙을 정의합니다. 

## 응답 스펙
### 성공 (HTTP 200):

``` json
{
  "url": "https://www.musinsa.com/products/3879297",
  "productName": "무신사 스탠다드 코튼 티셔츠",
  "brandName": "MUSINSA",
  "imageUrl": "https://image.musinsa.com/...",
  "extracted_via": "static"
}
```
### 추출 실패 (HTTP 200, null 반환):
```json
{
  "url": "https://...",
  "productName": null,
  "brandName": null,
  "imageUrl": null,
  "extracted_via": "error"
}
```
### 잘못된 URL / SSRF 차단 (HTTP 400):
```json
{
  "error": "INVALID_URL",
  "detail": "URL format is invalid or target IP is in a blocked range"
}
```

## 주요 고민 및 결정 사항

### extracted_via 필드를 Nullable로 둔 이유
현재 구조상 해당 필드에는 "static", "playwright", "error" 중 하나의 값이 항상 채워집니다. 
하지만 추출 로직 자체가 시도되지 않는 예외적인 상황을 위한 안전망(Safety net) 역할로 Null을 허용했습니다. 
모델 레벨에서 Null을 강제로 막아버리면 예상치 못한 경로에서 런타임 에러가 발생할 위험이 있기 때문에, 안정성을 위해 Optional로 유지하기로 결정했습니다.

### 추출 실패 시 500이 아닌 200 상태 코드를 반환하는 이유
URL 추출 실패를 시스템 장애(500)가 아닌, 클라이언트가 대응 가능한 상태로 처리하여 Graceful Degradation을 구현하고자 했습니다. 
500 에러를 던질 경우 Spring Boot 환경에서 원치 않는 재시도 로직이 타거나 에러 페이지로 빠질 수 있습니다. 
따라서 200 OK와 함께 본문 필드를 null로 응답하여, 프론트엔드에서 사용자에게 수동 입력 폼을 띄워주는 방식으로 유연하게 대응하도록 설계했습니다.


[DK-462]: https://potenup-final.atlassian.net/browse/DK-462?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ