### PR TITLE
[FEAT] GET /extract 엔드포인트 및 SSRF 보안 가드 구현

### DIFF
--- a/api/extractor.py
+++ b/api/extractor.py
@@ -1,0 +1,169 @@
+import ipaddress
+import socket
+from typing import Optional
+from urllib.parse import urljoin, urlparse
+
+from bs4 import BeautifulSoup
+
+from core.config import BROWSER_USER_AGENT, CURL_IMPERSONATE
+
+STATIC_TIMEOUT = 2
+
+_STATIC_HEADERS = {
+    "User-Agent": BROWSER_USER_AGENT,
+    "Accept-Language": "ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7",
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+}
+
+_BLOCKED_NETWORKS = [
+    ipaddress.ip_network("10.0.0.0/8"),
+    ipaddress.ip_network("172.16.0.0/12"),
+    ipaddress.ip_network("192.168.0.0/16"),
+    ipaddress.ip_network("127.0.0.0/8"),
+    ipaddress.ip_network("169.254.0.0/16"),
+    ipaddress.ip_network("::1/128"),
+    ipaddress.ip_network("fc00::/7"),
+]
+
+
+class InvalidURLError(Exception):
+    pass
+
+
+class SSRFBlockedError(Exception):
+    pass
+
+
+def _is_blocked_ip(ip_str: str) -> bool:
+    try:
+        addr = ipaddress.ip_address(ip_str)
+        return any(addr in net for net in _BLOCKED_NETWORKS)
+    except ValueError:
+        return True
+
+
+def validate_and_guard(url: str) -> tuple[str, str]:
+    """
+    URL 형식 검증 + SSRF 차단.
+    통과하면 (resolved_ip, hostname) 반환.
+    """
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https") or not parsed.netloc:
+        raise InvalidURLError(f"유효하지 않은 URL 형식: {url}")
+
+    hostname = parsed.hostname
+    if not hostname:
+        raise InvalidURLError(f"hostname을 파싱할 수 없음: {url}")
+
+    try:
+        results = socket.getaddrinfo(hostname, None, socket.AF_UNSPEC, socket.SOCK_STREAM)
+    except socket.gaierror as e:
+        raise SSRFBlockedError(f"DNS 해석 실패 ({hostname}): {e}")
+
+    if not results:
+        raise SSRFBlockedError(f"DNS 결과 없음: {hostname}")
+
+    ip_str = results[0][4][0]
+
+    if _is_blocked_ip(ip_str):
+        raise SSRFBlockedError(f"차단된 IP 범위: {ip_str}")
+
+    return ip_str, hostname
+
+
+def static_fetch(url: str, resolved_ip: str, hostname: str) -> Optional[str]:
+    """
+    curl_cffi로 정적 HTML fetch. 실패 시 requests로 폴백.
+    DNS 리바인딩 방어: 해석된 IP에 직접 연결 + Host 헤더로 원래 hostname 전달.
+    """
+    parsed = urlparse(url)
+    port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    pinned_url = parsed._replace(netloc=f"{resolved_ip}:{port}").geturl()
+    headers = {**_STATIC_HEADERS, "Host": hostname}
+
+    try:
+        from curl_cffi import requests as cffi_requests
+        resp = cffi_requests.get(
+            pinned_url,
+            headers=headers,
+            timeout=STATIC_TIMEOUT,
+            impersonate=CURL_IMPERSONATE,
+            verify=False,
+        )
+        resp.raise_for_status()
+        return resp.text
+    except Exception:
+        pass
+
+    try:
+        import requests
+        resp = requests.get(
+            pinned_url,
+            headers=headers,
+            timeout=STATIC_TIMEOUT,
+            verify=False,
+        )
+        resp.raise_for_status()
+        return resp.text
+    except Exception:
+        return None
+
+
+def parse_og(html: str, base_url: str) -> dict:
+    """BeautifulSoup으로 OG 태그 파싱. 우선순위 체인 적용."""
+    soup = BeautifulSoup(html, "html.parser")
+
+    def og(prop: str) -> Optional[str]:
+        tag = soup.find("meta", property=prop)
+        return tag["content"].strip() if tag and tag.get("content") else None
+
+    def meta_name(name: str) -> Optional[str]:
+        tag = soup.find("meta", attrs={"name": name})
+        return tag["content"].strip() if tag and tag.get("content") else None
+
+    # productName: og:title → <title>
+    product_name = og("og:title")
+    if not product_name:
+        title_tag = soup.find("title")
+        product_name = title_tag.get_text(strip=True) if title_tag else None
+
+    # imageUrl: og:image (상대경로 → 절대경로)
+    image_url = og("og:image")
+    if image_url and not image_url.startswith("http"):
+        image_url = urljoin(base_url, image_url)
+
+    # brandName: og:site_name → <meta name="author">
+    brand_name = og("og:site_name") or meta_name("author")
+
+    return {
+        "productName": product_name or None,
+        "brandName": brand_name or None,
+        "imageUrl": image_url or None,
+    }
+
+
+def extract_static(url: str) -> dict:
+    """
+    SSRF 가드 → 정적 fetch → OG 파싱.
+    반환: {"productName", "brandName", "imageUrl", "extracted_via"}
+    SSRF/URL 오류 시 {"error", "detail"} 반환.
+    """
+    try:
+        resolved_ip, hostname = validate_and_guard(url)
+    except (InvalidURLError, SSRFBlockedError) as e:
+        return {"error": "INVALID_URL", "detail": str(e)}
+
+    html = static_fetch(url, resolved_ip, hostname)
+    if not html:
+        return {
+            "productName": None,
+            "brandName": None,
+            "imageUrl": None,
+            "extracted_via": "error",
+        }
+
+    og = parse_og(html, url)
+
+    extracted_via = "static" if (og["productName"] or og["imageUrl"]) else "error"
+
+    return {**og, "extracted_via": extracted_via}

--- a/api/main.py
+++ b/api/main.py
@@ -1,8 +1,42 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+
+from api.extractor import InvalidURLError, SSRFBlockedError, extract_static, validate_and_guard
+from api.schemas import ExtractionResult
 
 app = FastAPI(title="DEKK Crawler API")
+
+
+@app.exception_handler(RequestValidationError)
+async def validation_exception_handler(request: Request, exc: RequestValidationError):
+    return JSONResponse(
+        status_code=400,
+        content={"error": "INVALID_URL", "detail": "유효하지 않은 URL 형식입니다"},
+    )
 
 
 @app.get("/health")
 def health_check():
     return {"status": "ok"}
+
+
+@app.get("/extract", response_model=ExtractionResult)
+def extract(url: str):
+    try:
+        validate_and_guard(url)
+    except (InvalidURLError, SSRFBlockedError) as e:
+        return JSONResponse(
+            status_code=400,
+            content={"error": "INVALID_URL", "detail": str(e)},
+        )
+
+    result = extract_static(url)
+
+    if "error" in result and "detail" in result:
+        return JSONResponse(
+            status_code=400,
+            content=result,
+        )
+
+    return ExtractionResult(url=url, **result)

--- a/core/config.py
+++ b/core/config.py
@@ -7,8 +7,11 @@ LOG_DIR = os.path.join(BASE_DIR, 'logs')
 
 STATE_FILE_PATH = os.path.join(DATA_DIR, "crawler_state.json")
 
-os.makedirs(DATA_DIR, exist_ok=True)
-os.makedirs(LOG_DIR, exist_ok=True)
+try:
+    os.makedirs(DATA_DIR, exist_ok=True)
+    os.makedirs(LOG_DIR, exist_ok=True)
+except OSError:
+    pass
 
 # ── 파이프라인 설정 ───────────────────────────────────────
 MAX_WORKERS = 5


### PR DESCRIPTION
## #️⃣ 연관된 이슈
[DK-463](https://potenup-final.atlassian.net/browse/DK-463)

## 📝 작업 내용
  - `GET /extract?url={target_url}` 엔드포인트 추가
  - URL 포맷 검증 → 유효하지 않으면 HTTP 400 반환
  - SSRF 보안 가드
    - `socket.getaddrinfo()`로 hostname → IP 해석
    - RFC1918(10.x, 172.16-31.x, 192.168.x), loopback(127.x), link-local(169.254.x) 차단
    - DNS 리바인딩 방어: 해석된 IP에 직접 연결 + `Host` 헤더로 원래 hostname 전달
    - 차단된 IP → HTTP 400 반환
  - FastAPI 기본 422 → 400 오버라이드 (커스텀 예외 핸들러)

## 리뷰
- 이해 되지 않는 부분이나 보안적으로 문제가 될 수 있는 부분이 있는지 확인 부탁드립니다!

[DK-463]: https://potenup-final.atlassian.net/browse/DK-463?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ