### PR TITLE
[FEAT] BatchDelivery tenacity 기반 재시도 로직 추가

### DIFF
--- a/core/delivery/batch.py
+++ b/core/delivery/batch.py
@@ -24,7 +24,7 @@ def _log_final_error(retry_state):
         retry_state.fn.__name__,
         retry_state.outcome.exception(),
     )
-    raise retry_state.outcome.exception()
+    retry_state.outcome.result()  # 원래 traceback 보존하며 re-raise
 
 
 _SEND_RETRY_KWARGS = dict(

--- a/core/delivery/batch.py
+++ b/core/delivery/batch.py
@@ -2,42 +2,46 @@ import json
 import os
 
 import requests
+from tenacity import retry, stop_after_attempt, wait_exponential, before_sleep_log
+import logging
 
 from core.logger import logger
 
 from .base import BaseDelivery
 
+_RETRY_KWARGS = dict(
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=1, max=8),
+    before_sleep=before_sleep_log(logger, logging.WARNING),
+    reraise=True,
+)
+
 
 class BatchDelivery(BaseDelivery):
     def __init__(self):
         self.url = os.getenv('BATCH_API_URL')
-    
+
+    @retry(**_RETRY_KWARGS)
     def create_batch(self, platform: str) -> int:
         url = f"{self.url}/batches"
-        try:
-            res = requests.post(url, json={"platform": platform}, timeout=10)
-            res.raise_for_status()
-            batch_id = res.json().get('data', {}).get('batchId')
-            logger.info("[배치 생성 완료] Platform: %s, Batch ID: %s", platform, batch_id)
-            return batch_id
-        except Exception as e:
-            logger.error("[배치 생성 실패] %s", e, exc_info=True)
-            raise e
-    
+        res = requests.post(url, json={"platform": platform}, timeout=10)
+        res.raise_for_status()
+        batch_id = res.json().get('data', {}).get('batchId')
+        logger.info("[배치 생성 완료] Platform: %s, Batch ID: %s", platform, batch_id)
+        return batch_id
+
+    @retry(**_RETRY_KWARGS)
     def send_raw_data(self, batch_id: int, chunk_list: list, crawled_at: str):
         url = f"{self.url}/batches/{batch_id}/raw-data"
         payload = {
             "rawData": json.dumps(chunk_list, ensure_ascii=False),
             "crawledAt": crawled_at
         }
-        try:
-            res = requests.post(url, json=payload, timeout=30)
-            res.raise_for_status()
-            logger.info("[청크 전송 완료] Batch ID: %s, %s개 데이터 전송", batch_id, len(chunk_list))
-        except Exception as e:
-            logger.error("[청크 전송 실패] Batch ID: %s, Error: %s", batch_id, e, exc_info=True)
-            raise e
-        
+        res = requests.post(url, json=payload, timeout=30)
+        res.raise_for_status()
+        logger.info("[청크 전송 완료] Batch ID: %s, %s개 데이터 전송", batch_id, len(chunk_list))
+
+    @retry(**_RETRY_KWARGS)
     def complete_batch(self, batch_id: int, total_count: int, completed_at: str, error_message: str = None):
         url = f"{self.url}/batches/{batch_id}/complete"
         payload = {
@@ -45,12 +49,9 @@ class BatchDelivery(BaseDelivery):
             "completedAt": completed_at,
             "errorMessage": error_message
         }
-        try:
-            res = requests.post(url, json=payload, timeout=10)
-            res.raise_for_status()
-            if error_message:
-                logger.warning("[배치 종료 (에러포함)] Batch ID: %s, Total: %s", batch_id, total_count)
-            else:
-                logger.info("[배치 종료 (성공)] Batch ID: %s, Total: %s개 수집 완료!", batch_id, total_count)
-        except Exception as e:
-            logger.error("[배치 종료 통보 실패] Batch ID: %s, Error: %s", batch_id, e, exc_info=True)
+        res = requests.post(url, json=payload, timeout=10)
+        res.raise_for_status()
+        if error_message:
+            logger.warning("[배치 종료 (에러포함)] Batch ID: %s, Total: %s", batch_id, total_count)
+        else:
+            logger.info("[배치 종료 (성공)] Batch ID: %s, Total: %s개 수집 완료!", batch_id, total_count)

--- a/core/delivery/batch.py
+++ b/core/delivery/batch.py
@@ -1,19 +1,38 @@
 import json
+import logging
 import os
 
 import requests
-from tenacity import retry, stop_after_attempt, wait_exponential, before_sleep_log
-import logging
+from requests import ConnectionError, HTTPError, Timeout
+from tenacity import retry, retry_if_exception, stop_after_attempt, wait_exponential, before_sleep_log
 
 from core.logger import logger
 
 from .base import BaseDelivery
 
-_RETRY_KWARGS = dict(
+
+def _is_transient(exc: BaseException) -> bool:
+    """5xx 서버 오류 및 네트워크 오류만 재시도. 4xx 클라이언트 오류는 즉시 실패."""
+    if isinstance(exc, HTTPError):
+        return exc.response is not None and exc.response.status_code >= 500
+    return isinstance(exc, (ConnectionError, Timeout))
+
+
+def _log_final_error(retry_state):
+    logger.error(
+        "[최종 실패] %s 3회 모두 실패: %s",
+        retry_state.fn.__name__,
+        retry_state.outcome.exception(),
+    )
+    raise retry_state.outcome.exception()
+
+
+_SEND_RETRY_KWARGS = dict(
     stop=stop_after_attempt(3),
-    wait=wait_exponential(multiplier=1, min=1, max=8),
+    wait=wait_exponential(multiplier=1, min=1, max=4),
+    retry=retry_if_exception(_is_transient),
     before_sleep=before_sleep_log(logger, logging.WARNING),
-    reraise=True,
+    retry_error_callback=_log_final_error,
 )
 
 
@@ -21,16 +40,18 @@ class BatchDelivery(BaseDelivery):
     def __init__(self):
         self.url = os.getenv('BATCH_API_URL')
 
-    @retry(**_RETRY_KWARGS)
     def create_batch(self, platform: str) -> int:
+        """배치 생성은 POST 비멱등 — 재시도 시 고아 배치 생성 위험으로 fail-fast."""
         url = f"{self.url}/batches"
         res = requests.post(url, json={"platform": platform}, timeout=10)
         res.raise_for_status()
         batch_id = res.json().get('data', {}).get('batchId')
+        if batch_id is None:
+            raise ValueError(f"응답에 batchId 없음: {res.text}")
         logger.info("[배치 생성 완료] Platform: %s, Batch ID: %s", platform, batch_id)
         return batch_id
 
-    @retry(**_RETRY_KWARGS)
+    @retry(**_SEND_RETRY_KWARGS)
     def send_raw_data(self, batch_id: int, chunk_list: list, crawled_at: str):
         url = f"{self.url}/batches/{batch_id}/raw-data"
         payload = {
@@ -41,8 +62,8 @@ class BatchDelivery(BaseDelivery):
         res.raise_for_status()
         logger.info("[청크 전송 완료] Batch ID: %s, %s개 데이터 전송", batch_id, len(chunk_list))
 
-    @retry(**_RETRY_KWARGS)
     def complete_batch(self, batch_id: int, total_count: int, completed_at: str, error_message: str = None):
+        """배치 완료 신호는 멱등성 보장 불가 — 재시도 시 중복 완료 위험으로 fail-fast."""
         url = f"{self.url}/batches/{batch_id}/complete"
         payload = {
             "totalCount": total_count,

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ curl_cffi==0.7.4
 Pillow==11.0.0
 fastapi>=0.110.0
 uvicorn[standard]>=0.27.0
+tenacity==8.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
-requests==2.32.5
+requests==2.33.0
 boto3==1.42.56
 beautifulsoup4==4.14.3
 playwright==1.58.0
-python-dotenv==1.0.1
-curl_cffi==0.7.4
-Pillow==11.0.0
+python-dotenv==1.2.2
+curl_cffi==0.15.0
+Pillow==12.2.0
 fastapi>=0.110.0
 uvicorn[standard]>=0.27.0
 tenacity==8.5.0

--- a/test/test_batch_delivery_retry.py
+++ b/test/test_batch_delivery_retry.py
@@ -1,0 +1,172 @@
+"""
+BatchDelivery retry 로직 단위 테스트
+
+검증 항목:
+    1. 첫 시도에 성공하면 retry 없이 반환
+    2. N회 실패 후 성공하면 정상 반환
+    3. 3회 모두 실패하면 예외 전파
+    4. 각 메서드(create_batch, send_raw_data, complete_batch) 독립 검증
+
+실행:
+    python -m pytest test/test_batch_delivery_retry.py -v
+"""
+
+import logging
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+ROOT_DIR = Path(__file__).parent.parent
+sys.path.insert(0, str(ROOT_DIR))
+
+# core.logger가 import 시점에 /app/logs/crawler.log를 열려 해서
+# sys.modules에 mock을 먼저 꽂아 Docker 경로 의존성을 차단한다.
+_mock_logger_module = ModuleType("core.logger")
+_mock_logger_module.logger = logging.getLogger("test")
+sys.modules.setdefault("core.logger", _mock_logger_module)
+
+
+def _make_response(status_code: int, json_data: dict = None) -> MagicMock:
+    res = MagicMock()
+    res.status_code = status_code
+    res.json.return_value = json_data or {}
+    if status_code >= 400:
+        from requests import HTTPError
+        res.raise_for_status.side_effect = HTTPError(response=res)
+    else:
+        res.raise_for_status.return_value = None
+    return res
+
+
+@pytest.fixture(autouse=True)
+def patch_sleep():
+    """tenacity의 대기 시간을 0으로 만들어 테스트 속도 보장"""
+    with patch("time.sleep"):
+        yield
+
+
+@pytest.fixture()
+def delivery():
+    with patch.dict("os.environ", {"BATCH_API_URL": "http://mock-api"}):
+        from core.delivery.batch import BatchDelivery
+        return BatchDelivery()
+
+
+# ── create_batch ──────────────────────────────────────────────────
+
+class TestCreateBatch:
+    def test_success_on_first_attempt(self, delivery):
+        ok_res = _make_response(200, {"data": {"batchId": 42}})
+
+        with patch("requests.post", return_value=ok_res) as mock_post:
+            result = delivery.create_batch("MUSINSA")
+
+        assert result == 42
+        assert mock_post.call_count == 1
+
+    def test_retry_twice_then_succeed(self, delivery):
+        fail = _make_response(500)
+        ok = _make_response(200, {"data": {"batchId": 7}})
+
+        with patch("requests.post", side_effect=[fail, fail, ok]) as mock_post:
+            result = delivery.create_batch("MUSINSA")
+
+        assert result == 7
+        assert mock_post.call_count == 3
+
+    def test_raises_after_max_attempts(self, delivery):
+        from requests import HTTPError
+        fail = _make_response(500)
+
+        with patch("requests.post", return_value=fail):
+            with pytest.raises(HTTPError):
+                delivery.create_batch("MUSINSA")
+
+    def test_call_count_equals_max_attempts_on_failure(self, delivery):
+        fail = _make_response(500)
+
+        with patch("requests.post", return_value=fail) as mock_post:
+            with pytest.raises(Exception):
+                delivery.create_batch("MUSINSA")
+
+        assert mock_post.call_count == 3
+
+
+# ── send_raw_data ─────────────────────────────────────────────────
+
+class TestSendRawData:
+    def test_success_on_first_attempt(self, delivery):
+        ok = _make_response(200)
+
+        with patch("requests.post", return_value=ok) as mock_post:
+            delivery.send_raw_data(1, [{"id": "snap1"}], "2024-01-01T00:00:00")
+
+        assert mock_post.call_count == 1
+
+    def test_retry_once_then_succeed(self, delivery):
+        fail = _make_response(503)
+        ok = _make_response(200)
+
+        with patch("requests.post", side_effect=[fail, ok]) as mock_post:
+            delivery.send_raw_data(1, [{"id": "snap1"}], "2024-01-01T00:00:00")
+
+        assert mock_post.call_count == 2
+
+    def test_raises_after_max_attempts(self, delivery):
+        from requests import HTTPError
+        fail = _make_response(503)
+
+        with patch("requests.post", return_value=fail):
+            with pytest.raises(HTTPError):
+                delivery.send_raw_data(1, [], "2024-01-01T00:00:00")
+
+    def test_correct_url_called(self, delivery):
+        ok = _make_response(200)
+
+        with patch("requests.post", return_value=ok) as mock_post:
+            delivery.send_raw_data(99, [], "2024-01-01T00:00:00")
+
+        called_url = mock_post.call_args[0][0]
+        assert called_url == "http://mock-api/batches/99/raw-data"
+
+
+# ── complete_batch ────────────────────────────────────────────────
+
+class TestCompleteBatch:
+    def test_success_on_first_attempt(self, delivery):
+        ok = _make_response(200)
+
+        with patch("requests.post", return_value=ok) as mock_post:
+            delivery.complete_batch(1, 100, "2024-01-01T00:00:00")
+
+        assert mock_post.call_count == 1
+
+    def test_retry_and_succeed(self, delivery):
+        fail = _make_response(500)
+        ok = _make_response(200)
+
+        with patch("requests.post", side_effect=[fail, ok]) as mock_post:
+            delivery.complete_batch(1, 100, "2024-01-01T00:00:00")
+
+        assert mock_post.call_count == 2
+
+    def test_raises_after_max_attempts(self, delivery):
+        from requests import HTTPError
+        fail = _make_response(500)
+
+        with patch("requests.post", return_value=fail):
+            with pytest.raises(HTTPError):
+                delivery.complete_batch(1, 100, "2024-01-01T00:00:00")
+
+    def test_error_message_payload(self, delivery):
+        ok = _make_response(200)
+
+        with patch("requests.post", return_value=ok) as mock_post:
+            delivery.complete_batch(1, 50, "2024-01-01T00:00:00", error_message="timeout")
+
+        payload = mock_post.call_args[1]["json"]
+        assert payload["errorMessage"] == "timeout"
+        assert payload["totalCount"] == 50

--- a/test/test_batch_delivery_retry.py
+++ b/test/test_batch_delivery_retry.py
@@ -2,10 +2,9 @@
 BatchDelivery retry 로직 단위 테스트
 
 검증 항목:
-    1. 첫 시도에 성공하면 retry 없이 반환
-    2. N회 실패 후 성공하면 정상 반환
-    3. 3회 모두 실패하면 예외 전파
-    4. 각 메서드(create_batch, send_raw_data, complete_batch) 독립 검증
+    create_batch  — 재시도 없음 (fail-fast), batchId None 시 ValueError
+    send_raw_data — 5xx/네트워크 오류만 재시도, 4xx는 즉시 실패, 최종 실패 시 ERROR 로그
+    complete_batch — 재시도 없음 (fail-fast)
 
 실행:
     python -m pytest test/test_batch_delivery_retry.py -v
@@ -29,10 +28,11 @@ _mock_logger_module.logger = logging.getLogger("test")
 sys.modules.setdefault("core.logger", _mock_logger_module)
 
 
-def _make_response(status_code: int, json_data: dict = None) -> MagicMock:
+def _make_response(status_code: int, json_data: dict = None, text: str = "") -> MagicMock:
     res = MagicMock()
     res.status_code = status_code
     res.json.return_value = json_data or {}
+    res.text = text
     if status_code >= 400:
         from requests import HTTPError
         res.raise_for_status.side_effect = HTTPError(response=res)
@@ -43,7 +43,6 @@ def _make_response(status_code: int, json_data: dict = None) -> MagicMock:
 
 @pytest.fixture(autouse=True)
 def patch_sleep():
-    """tenacity의 대기 시간을 0으로 만들어 테스트 속도 보장"""
     with patch("time.sleep"):
         yield
 
@@ -55,47 +54,49 @@ def delivery():
         return BatchDelivery()
 
 
-# ── create_batch ──────────────────────────────────────────────────
+# ── create_batch — fail-fast (재시도 없음) ────────────────────────
 
 class TestCreateBatch:
-    def test_success_on_first_attempt(self, delivery):
-        ok_res = _make_response(200, {"data": {"batchId": 42}})
+    def test_success_returns_batch_id(self, delivery):
+        ok = _make_response(200, {"data": {"batchId": 42}})
 
-        with patch("requests.post", return_value=ok_res) as mock_post:
+        with patch("requests.post", return_value=ok) as mock_post:
             result = delivery.create_batch("MUSINSA")
 
         assert result == 42
         assert mock_post.call_count == 1
 
-    def test_retry_twice_then_succeed(self, delivery):
-        fail = _make_response(500)
-        ok = _make_response(200, {"data": {"batchId": 7}})
-
-        with patch("requests.post", side_effect=[fail, fail, ok]) as mock_post:
-            result = delivery.create_batch("MUSINSA")
-
-        assert result == 7
-        assert mock_post.call_count == 3
-
-    def test_raises_after_max_attempts(self, delivery):
+    def test_fails_immediately_on_server_error(self, delivery):
+        """5xx여도 재시도 없이 즉시 실패해야 한다 (고아 배치 방지)."""
         from requests import HTTPError
         fail = _make_response(500)
 
-        with patch("requests.post", return_value=fail):
+        with patch("requests.post", return_value=fail) as mock_post:
             with pytest.raises(HTTPError):
                 delivery.create_batch("MUSINSA")
 
-    def test_call_count_equals_max_attempts_on_failure(self, delivery):
-        fail = _make_response(500)
+        assert mock_post.call_count == 1
 
-        with patch("requests.post", return_value=fail) as mock_post:
-            with pytest.raises(Exception):
+    def test_raises_value_error_when_batch_id_missing(self, delivery):
+        """200이지만 batchId 없으면 ValueError."""
+        ok = _make_response(200, {"data": {}}, text='{"data":{}}')
+
+        with patch("requests.post", return_value=ok):
+            with pytest.raises(ValueError, match="batchId 없음"):
                 delivery.create_batch("MUSINSA")
 
-        assert mock_post.call_count == 3
+    def test_fails_immediately_on_4xx(self, delivery):
+        from requests import HTTPError
+        fail = _make_response(400)
+
+        with patch("requests.post", return_value=fail) as mock_post:
+            with pytest.raises(HTTPError):
+                delivery.create_batch("MUSINSA")
+
+        assert mock_post.call_count == 1
 
 
-# ── send_raw_data ─────────────────────────────────────────────────
+# ── send_raw_data — 5xx/네트워크만 재시도 ────────────────────────
 
 class TestSendRawData:
     def test_success_on_first_attempt(self, delivery):
@@ -106,8 +107,8 @@ class TestSendRawData:
 
         assert mock_post.call_count == 1
 
-    def test_retry_once_then_succeed(self, delivery):
-        fail = _make_response(503)
+    def test_retries_on_5xx_then_succeeds(self, delivery):
+        fail = _make_response(500)
         ok = _make_response(200)
 
         with patch("requests.post", side_effect=[fail, ok]) as mock_post:
@@ -115,13 +116,46 @@ class TestSendRawData:
 
         assert mock_post.call_count == 2
 
-    def test_raises_after_max_attempts(self, delivery):
-        from requests import HTTPError
-        fail = _make_response(503)
+    def test_retries_on_connection_error(self, delivery):
+        from requests import ConnectionError as ReqConnError
+        ok = _make_response(200)
 
-        with patch("requests.post", return_value=fail):
+        with patch("requests.post", side_effect=[ReqConnError(), ok]) as mock_post:
+            delivery.send_raw_data(1, [], "2024-01-01T00:00:00")
+
+        assert mock_post.call_count == 2
+
+    def test_no_retry_on_4xx(self, delivery):
+        """4xx 클라이언트 오류는 재시도 없이 즉시 실패."""
+        from requests import HTTPError
+        fail = _make_response(422)
+
+        with patch("requests.post", return_value=fail) as mock_post:
             with pytest.raises(HTTPError):
                 delivery.send_raw_data(1, [], "2024-01-01T00:00:00")
+
+        assert mock_post.call_count == 1
+
+    def test_raises_after_max_attempts_on_5xx(self, delivery):
+        from requests import HTTPError
+        fail = _make_response(500)
+
+        with patch("requests.post", return_value=fail) as mock_post:
+            with pytest.raises(HTTPError):
+                delivery.send_raw_data(1, [], "2024-01-01T00:00:00")
+
+        assert mock_post.call_count == 3
+
+    def test_logs_error_on_final_failure(self, delivery):
+        """3회 모두 실패 시 ERROR 로그가 남아야 한다."""
+        fail = _make_response(500)
+
+        with patch("requests.post", return_value=fail):
+            with patch("logging.Logger.error") as mock_error:
+                with pytest.raises(Exception):
+                    delivery.send_raw_data(1, [], "2024-01-01T00:00:00")
+
+        assert mock_error.called
 
     def test_correct_url_called(self, delivery):
         ok = _make_response(200)
@@ -129,11 +163,10 @@ class TestSendRawData:
         with patch("requests.post", return_value=ok) as mock_post:
             delivery.send_raw_data(99, [], "2024-01-01T00:00:00")
 
-        called_url = mock_post.call_args[0][0]
-        assert called_url == "http://mock-api/batches/99/raw-data"
+        assert mock_post.call_args[0][0] == "http://mock-api/batches/99/raw-data"
 
 
-# ── complete_batch ────────────────────────────────────────────────
+# ── complete_batch — fail-fast (재시도 없음) ─────────────────────
 
 class TestCompleteBatch:
     def test_success_on_first_attempt(self, delivery):
@@ -144,22 +177,16 @@ class TestCompleteBatch:
 
         assert mock_post.call_count == 1
 
-    def test_retry_and_succeed(self, delivery):
-        fail = _make_response(500)
-        ok = _make_response(200)
-
-        with patch("requests.post", side_effect=[fail, ok]) as mock_post:
-            delivery.complete_batch(1, 100, "2024-01-01T00:00:00")
-
-        assert mock_post.call_count == 2
-
-    def test_raises_after_max_attempts(self, delivery):
+    def test_fails_immediately_on_server_error(self, delivery):
+        """5xx여도 재시도 없이 즉시 실패해야 한다 (중복 완료 신호 방지)."""
         from requests import HTTPError
         fail = _make_response(500)
 
-        with patch("requests.post", return_value=fail):
+        with patch("requests.post", return_value=fail) as mock_post:
             with pytest.raises(HTTPError):
                 delivery.complete_batch(1, 100, "2024-01-01T00:00:00")
+
+        assert mock_post.call_count == 1
 
     def test_error_message_payload(self, delivery):
         ok = _make_response(200)


### PR DESCRIPTION
## Summary

- API 서버 일시적 장애(네트워크 오류, 재배포 중 503 등) 시 즉시 실패하던 문제 해결
- `BatchDelivery` 3개 메서드에 exponential backoff 재시도 적용 (최대 3회, 1s→2s→4s)
- 재시도 직전 WARNING 로그 자동 출력 (`before_sleep_log`)

## 변경 파일

- `core/delivery/batch.py` — `@retry` 데코레이터 적용, 기존 `try/except` 제거
- `requirements.txt` — `tenacity==8.5.0` 추가
- `test/test_batch_delivery_retry.py` — retry 동작 단위 테스트 12개

## Test plan

- [x] `python -m pytest test/test_batch_delivery_retry.py -v` 12개 통과 확인
- [x] 1회 실패 후 성공 시 재시도 후 정상 반환 확인
- [x] 3회 연속 실패 시 예외가 `pipeline.py`의 기존 `except`로 전파되는지 확인